### PR TITLE
Okhttp implementation of HttpClient interface

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: java
+sudo: false
+
+jdk:
+  - oraclejdk8
+  
+env:
+  - DISPLAY=:99.0
+
+before_install:
+  - "sh -e /etc/init.d/xvfb start"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ env:
 
 before_install:
   - "sh -e /etc/init.d/xvfb start"
+
+script:
+  - mvn package

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.20</version>
+                <version>2.22.0</version>
                 <configuration>
                     <surefire.useFile>false</surefire.useFile>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,12 @@
             <version>${slf4j-version}</version>
         </dependency>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j-version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient-version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <java-version>1.8</java-version>
         <slf4j-version>1.7.25</slf4j-version>
         <junit.version>4.11</junit.version>
-        <httpclient-version>4.5.3</httpclient-version>
         <okhttp-version>3.11.0</okhttp-version>
+        <httpclient-version>4.5.6</httpclient-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>4.0.0</version>
                 <configuration>
                     <manifestLocation>META-INF</manifestLocation>
                     <instructions>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,8 @@
 
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.1.0</version>
                 <configuration>
-                    <useDefaultManifestFile>true</useDefaultManifestFile>
                     <archive>
                         <index>true</index>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <slf4j-version>1.7.25</slf4j-version>
         <junit.version>4.11</junit.version>
         <httpclient-version>4.5.3</httpclient-version>
+        <okhttp-version>3.11.0</okhttp-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -161,6 +162,11 @@
                     <groupId>commons-logging</groupId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>okhttp</artifactId>
+            <version>${okhttp-version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.2</version>
+                <version>3.8.0</version>
                 <configuration>
                     <source>${java-version}</source>
                     <target>${java-version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <properties>
         <java-version>1.8</java-version>
         <slf4j-version>1.7.25</slf4j-version>
-        <junit.version>4.11</junit.version>
         <okhttp-version>3.11.0</okhttp-version>
+        <junit.version>4.12</junit.version>
         <httpclient-version>4.5.6</httpclient-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.4</version>
+                <version>3.0.1</version>
                 <configuration>
                     <excludePackageNames>*.internal.*</excludePackageNames>
                     <failOnError>false</failOnError>

--- a/src/main/java/com/brsanthu/googleanalytics/GoogleAnalyticsConfig.java
+++ b/src/main/java/com/brsanthu/googleanalytics/GoogleAnalyticsConfig.java
@@ -30,13 +30,16 @@ import com.brsanthu.googleanalytics.internal.GoogleAnalyticsStatsImpl;
  * @author Santhosh Kumar
  */
 public class GoogleAnalyticsConfig {
+
+    public static final int DEFAULT_MAX_HTTP_CONNECTIONS_PER_ROUTE = 10;
+
     private String threadNameFormat = "googleanalyticsjava-thread-{0}";
     private boolean enabled = true;
     private int minThreads = 0;
     private int maxThreads = 5;
     private int threadTimeoutSecs = 300;
     private int threadQueueSize = 1000;
-    private int maxHttpConnectionsPerRoute = 10;
+    private int maxHttpConnectionsPerRoute = DEFAULT_MAX_HTTP_CONNECTIONS_PER_ROUTE;
     private boolean useHttps = true;
     private boolean validate = true;
     private boolean batchingEnabled = false;

--- a/src/main/java/com/brsanthu/googleanalytics/httpclient/OkHttpClientImpl.java
+++ b/src/main/java/com/brsanthu/googleanalytics/httpclient/OkHttpClientImpl.java
@@ -1,0 +1,185 @@
+package com.brsanthu.googleanalytics.httpclient;
+
+import static com.brsanthu.googleanalytics.internal.GaUtils.isNotEmpty;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.brsanthu.googleanalytics.GoogleAnalyticsConfig;
+
+import okhttp3.Authenticator;
+import okhttp3.Credentials;
+import okhttp3.FormBody;
+import okhttp3.OkHttpClient;
+import okhttp3.Response;
+import okhttp3.Route;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+
+public class OkHttpClientImpl implements HttpClient {
+    private static final Logger logger = LoggerFactory.getLogger(OkHttpClientImpl.class);
+
+    // Recommended to be singleton
+    private static OkHttpClient client;
+
+    public OkHttpClientImpl(GoogleAnalyticsConfig config) {
+        if (client == null) {
+            client = createHttpClient(config);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        // no close methods on OkHttp
+    }
+
+    /**
+     * HTTP Client that uses the OkHttp library for request/response. <strong>Not
+     * all GoogleAnalyticsCnofig options are supported</strong>. All unsupported
+     * options in the configuration will be checked on first usage and a
+     * RuntimeException will be thrown, so you may know your configuration is valid
+     * after making its first request.
+     *
+     * @param config the configuration to use while building OkHttpClient
+     * @return OkHttpClient to use for analytics hits
+     * @throws RuntimeException if unsupported configurations are specified
+     */
+    protected OkHttpClient createHttpClient(GoogleAnalyticsConfig config) throws RuntimeException {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+        checkConfigForUnsupportedConfiguration(config);
+
+        if (isNotEmpty(config.getProxyHost())) {
+            builder.proxy(new Proxy(Proxy.Type.HTTP, new InetSocketAddress(config.getProxyHost(), config.getProxyPort())));
+
+            if (isNotEmpty(config.getProxyUserName())) {
+                Authenticator proxyAuthenticator = new Authenticator() {
+
+                    @Override
+                    public Request authenticate(Route route, Response response) throws IOException {
+                        String credential = Credentials.basic(config.getProxyUserName(), config.getProxyPassword());
+
+                        return response.request().newBuilder().header("Proxy-Authorization", credential).build();
+                    }
+                };
+                builder.proxyAuthenticator(proxyAuthenticator);
+            }
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * OkHttp does not support everything Apache HttpClient supports at the library
+     * level. Additionally, this implementation doesn't implement everything
+     * supported in the ApacheHttpClientImpl
+     *
+     * This checks for unsupported configurations and throws immediately so
+     * validation will occur at least on the first attempt to use the library
+     *
+     * @param config the configuration to check
+     * @throws RuntimeException if any unsupported configurations are specified
+     */
+    private void checkConfigForUnsupportedConfiguration(GoogleAnalyticsConfig config) throws RuntimeException {
+
+        if (config.getMaxHttpConnectionsPerRoute() != GoogleAnalyticsConfig.DEFAULT_MAX_HTTP_CONNECTIONS_PER_ROUTE) {
+            throw new RuntimeException("Configuring maximum connections per route is not supported by OkHttp");
+        }
+        if (isNotEmpty(config.getUserAgent())) {
+            throw new RuntimeException("GoogleAnalyticsConfig.userAgent is not currently supported");
+        }
+    }
+
+    @Override
+    public HttpResponse post(HttpRequest req) {
+        HttpResponse resp = new HttpResponse();
+
+        FormBody.Builder formBuilder = new FormBody.Builder(StandardCharsets.UTF_8);
+        Map<String, String> reqParams = req.getBodyParams();
+        for (String key : reqParams.keySet()) {
+            if (logger.isTraceEnabled()) logger.trace("post() adding POST param " + key + " = " + reqParams.get(key));
+            formBuilder.add(key, reqParams.get(key));
+        }
+        RequestBody body = formBuilder.build();
+
+        Request request = new Request.Builder().url(req.getUrl()).post(body).build();
+        if (logger.isDebugEnabled()) logger.debug("HttpClient.post() url/body: " + request.url() + " / " + renderBody(body));
+
+        try {
+
+            Response okResp = client.newCall(request).execute();
+            if (logger.isDebugEnabled()) logger.debug("post() response code/success: " + okResp.code() + " / " + okResp.isSuccessful());
+            resp.setStatusCode(okResp.code());
+            okResp.close(); // this marks the response as consumed, and allows the connection to be re-used
+
+        } catch (Exception e) {
+            logger.warn("OkHttpClientImpl.post()/OkHttpClient.newCall() error", e);
+        }
+
+        return resp;
+    }
+
+    @Override
+    public HttpBatchResponse postBatch(HttpBatchRequest batchReq) {
+        HttpBatchResponse resp = new HttpBatchResponse();
+        final okio.Buffer bodyBuffer = new okio.Buffer();
+
+        // For each request in the batch, build up the encoded form string, and add it
+        // to the buffer
+        for (HttpRequest request : batchReq.getRequests()) {
+            FormBody.Builder formBuilder = new FormBody.Builder(StandardCharsets.UTF_8);
+            if (logger.isTraceEnabled()) logger.trace("postBatch() starting new request line");
+            Map<String, String> reqParams = request.getBodyParams();
+            for (String key : reqParams.keySet()) {
+                if (logger.isTraceEnabled()) logger.trace("post() adding POST param " + key + " = " + reqParams.get(key));
+                formBuilder.add(key, reqParams.get(key));
+            }
+            if (logger.isTraceEnabled()) logger.trace("postBatch() finishing request line");
+
+            try {
+                formBuilder.build().writeTo(bodyBuffer);
+            } catch (IOException ioe) {
+                logger.warn("postBatch() error while rendering batch entry", ioe);
+            }
+            bodyBuffer.writeString("\r\n", StandardCharsets.UTF_8);
+        }
+
+        Request request = new Request.Builder().url(batchReq.getUrl()).post(RequestBody.create(null, bodyBuffer.readUtf8())).build();
+        if (logger.isDebugEnabled()) logger.debug("HttpClient.post() url/body: " + request.url() + " / " + renderBody(request.body()));
+
+        try {
+
+            Response okResp = client.newCall(request).execute();
+            if (logger.isDebugEnabled()) logger.debug("post() response code/success: " + okResp.code() + " / " + okResp.isSuccessful());
+
+            resp.setStatusCode(okResp.code());
+
+        } catch (Exception e) {
+            logger.warn("OkHttpClientImpl.post()/OkHttpClient.newCall() error", e);
+        }
+
+        return resp;
+    }
+
+    @Override
+    public boolean isBatchSupported() {
+        return true;
+    }
+
+    private String renderBody(RequestBody requestBody) {
+        try {
+            final okio.Buffer buffer = new okio.Buffer();
+            requestBody.writeTo(buffer);
+            return buffer.readUtf8();
+        } catch (IOException ioe) {
+            logger.warn("renderBody() error writing body contents out", ioe);
+            return "";
+        }
+    }
+}

--- a/src/test/java/com/brsanthu/googleanalytics/GoogleAnalyticsOkHttpTest.java
+++ b/src/test/java/com/brsanthu/googleanalytics/GoogleAnalyticsOkHttpTest.java
@@ -1,0 +1,28 @@
+package com.brsanthu.googleanalytics;
+
+import static com.brsanthu.googleanalytics.internal.Constants.TEST_TRACKING_ID;
+
+import org.junit.BeforeClass;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.brsanthu.googleanalytics.httpclient.OkHttpClientImpl;
+
+public class GoogleAnalyticsOkHttpTest extends GoogleAnalyticsApacheHttpTest {
+    private static final Logger logger = LoggerFactory.getLogger(GoogleAnalyticsOkHttpTest.class);
+
+    @BeforeClass
+    public static void setup() {
+	    logger.debug("setup() starting");
+		ga = new GoogleAnalyticsOkHttpTest().getTestBuilder().build();
+	}
+    
+    @Override
+    protected GoogleAnalyticsBuilder getTestBuilder() {
+        return GoogleAnalytics.builder()
+                .withTrackingId(TEST_TRACKING_ID)
+                .withAppName("Junit OkHttp Test")
+                .withAppVersion("1.0.0")
+                .withHttpClient(new OkHttpClientImpl(new GoogleAnalyticsConfig()));
+    }
+}


### PR DESCRIPTION
Hi there! I think you've created the best open-source-compatible Google Analytics client library, and I'm planning on using it for http://github.com/ankidroid/AnkiDroid which has 1MM or so installed users so I'd like it to work well for us.

The Android platform has deprecated Apache HTTP client though, and it's generally cleaner to use a different implementation of HTTP on the platform in order to avoid dependency problems and work well into the future.

OkHttp is a reasonable alternate choice for HTTP layer so here I propose an implementation of your HttpClient interface using the OkHttp library as an alternative to the existing Apache HttpClient implementation.

I've taken care to test it, including [implementing Travis CI on my fork](https://travis-ci.com/mikehardy/google-analytics-java/builds) (side note: just sign up there and you can have it for the project for free with the .travis.yml in this PR) but I may have missed something. I have also taken care with regard to performance vs correctness and I believe my implementation allows all configuration items to result in the correct connections while still reusing connections if possible and resulting in faster test execution than the Apache HTTP implementation, but of course I could have missed something there as well. I'll happily work through any issues that arise if so.

Please let me know what you think, and if this is something you'd like to merge.

Thanks